### PR TITLE
Fixed a big logic error and cleaned it up.

### DIFF
--- a/Stronghold/src/org/usfirst/frc/team2526/robot/commands/loader/RollersPortcullis.java
+++ b/Stronghold/src/org/usfirst/frc/team2526/robot/commands/loader/RollersPortcullis.java
@@ -26,12 +26,7 @@ public class RollersPortcullis extends Command {
 
     // Make this return true when this Command no longer needs to run execute()
     protected boolean isFinished() {
-        if(Robot.oi.getPortcullisButton().equals(false)) {
-        	return true;
-        } else {
-        	return false;
-        }
-    	
+    	return !Robot.oi.getPortcullisButton().get();
     }
 
     // Called once after isFinished returns true


### PR DESCRIPTION
The previous code used `.equals()`. That is used for comparing objects. Since `Robot.oi.getPortcullisButton()` returns an object Button, comparing the to a mid summers night, eh, boolean, will always be false.

Instead, we want to use `Robot.oi.getPortcullisButton().get();` to get the state of the button.

Then, using the weird if (button) return false else return true structure is needlessly long.

Flipping a boolean is simply a `!`.
